### PR TITLE
Add SlotNumber (EIP-7843) to Gloas ExecutionPayload

### DIFF
--- a/spec/gloas/executionpayload.go
+++ b/spec/gloas/executionpayload.go
@@ -45,6 +45,7 @@ type ExecutionPayload struct {
 	BlobGasUsed     uint64
 	ExcessBlobGas   uint64
 	BlockAccessList BlockAccessList `dynssz-max:"MAX_BYTES_PER_TRANSACTION" ssz-max:"1073741824"`
+	SlotNumber      uint64
 }
 
 // String returns a string version of the structure.

--- a/spec/gloas/executionpayload_json.go
+++ b/spec/gloas/executionpayload_json.go
@@ -48,6 +48,7 @@ type executionPayloadJSON struct {
 	BlobGasUsed     string                     `json:"blob_gas_used"`
 	ExcessBlobGas   string                     `json:"excess_blob_gas"`
 	BlockAccessList string                     `json:"block_access_list"`
+	SlotNumber      string                     `json:"slot_number"`
 }
 
 // MarshalJSON implements json.Marshaler.
@@ -81,6 +82,7 @@ func (e *ExecutionPayload) MarshalJSON() ([]byte, error) {
 		BlobGasUsed:     strconv.FormatUint(e.BlobGasUsed, 10),
 		ExcessBlobGas:   strconv.FormatUint(e.ExcessBlobGas, 10),
 		BlockAccessList: fmt.Sprintf("%#x", e.BlockAccessList),
+		SlotNumber:      strconv.FormatUint(e.SlotNumber, 10),
 	})
 }
 
@@ -252,6 +254,12 @@ func (e *ExecutionPayload) UnmarshalJSON(input []byte) error {
 	if err != nil {
 		return errors.Wrap(err, "block_access_list")
 	}
+
+	tmpUint, err = strconv.ParseUint(string(bytes.Trim(raw["slot_number"], `"`)), 10, 64)
+	if err != nil {
+		return errors.Wrap(err, "slot_number")
+	}
+	e.SlotNumber = tmpUint
 
 	return nil
 }

--- a/spec/gloas/executionpayload_ssz.go
+++ b/spec/gloas/executionpayload_ssz.go
@@ -18,7 +18,7 @@ func (e *ExecutionPayload) MarshalSSZ() ([]byte, error) {
 // MarshalSSZTo ssz marshals the ExecutionPayload object to a target array
 func (e *ExecutionPayload) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	dst = buf
-	offset := int(532)
+	offset := int(540)
 
 	// Field (0) 'ParentHash'
 	dst = append(dst, e.ParentHash[:]...)
@@ -84,6 +84,9 @@ func (e *ExecutionPayload) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	dst = ssz.WriteOffset(dst, offset)
 	offset += len(e.BlockAccessList)
 
+	// Field (18) 'SlotNumber'
+	dst = ssz.MarshalUint64(dst, e.SlotNumber)
+
 	// Field (10) 'ExtraData'
 	if size := len(e.ExtraData); size > 32 {
 		err = ssz.ErrBytesLengthFn("ExecutionPayload.ExtraData", size, 32)
@@ -136,7 +139,7 @@ func (e *ExecutionPayload) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 func (e *ExecutionPayload) UnmarshalSSZ(buf []byte) error {
 	var err error
 	size := uint64(len(buf))
-	if size < 532 {
+	if size < 540 {
 		return ssz.ErrSize
 	}
 
@@ -178,7 +181,7 @@ func (e *ExecutionPayload) UnmarshalSSZ(buf []byte) error {
 		return ssz.ErrOffset
 	}
 
-	if o10 < 532 {
+	if o10 < 540 {
 		return ssz.ErrInvalidVariableOffset
 	}
 
@@ -213,6 +216,9 @@ func (e *ExecutionPayload) UnmarshalSSZ(buf []byte) error {
 	if o17 = ssz.ReadOffset(buf[528:532]); o17 > size || o14 > o17 {
 		return ssz.ErrOffset
 	}
+
+	// Field (18) 'SlotNumber'
+	e.SlotNumber = ssz.UnmarshallUint64(buf[532:540])
 
 	// Field (10) 'ExtraData'
 	{
@@ -283,7 +289,7 @@ func (e *ExecutionPayload) UnmarshalSSZ(buf []byte) error {
 
 // SizeSSZ returns the ssz encoded size in bytes for the ExecutionPayload object
 func (e *ExecutionPayload) SizeSSZ() (size int) {
-	size = 532
+	size = 540
 
 	// Field (10) 'ExtraData'
 	size += len(e.ExtraData)
@@ -421,6 +427,9 @@ func (e *ExecutionPayload) HashTreeRootWith(hh ssz.HashWalker) (err error) {
 		hh.Append(e.BlockAccessList)
 		hh.MerkleizeWithMixin(elemIndx, byteLen, (1073741824+31)/32)
 	}
+
+	// Field (18) 'SlotNumber'
+	hh.PutUint64(e.SlotNumber)
 
 	hh.Merkleize(indx)
 	return

--- a/spec/gloas/executionpayload_yaml.go
+++ b/spec/gloas/executionpayload_yaml.go
@@ -43,6 +43,7 @@ type executionPayloadYAML struct {
 	BlobGasUsed     uint64                `yaml:"blob_gas_used"`
 	ExcessBlobGas   uint64                `yaml:"excess_blob_gas"`
 	BlockAccessList string                `yaml:"block_access_list"`
+	SlotNumber      uint64                `yaml:"slot_number"`
 }
 
 // MarshalYAML implements yaml.Marshaler.
@@ -76,6 +77,7 @@ func (e *ExecutionPayload) MarshalYAML() ([]byte, error) {
 		BlobGasUsed:     e.BlobGasUsed,
 		ExcessBlobGas:   e.ExcessBlobGas,
 		BlockAccessList: fmt.Sprintf("%#x", e.BlockAccessList),
+		SlotNumber:      e.SlotNumber,
 	}, yaml.Flow(true))
 	if err != nil {
 		return nil, err

--- a/spec/gloas/executionpayloadheader.go
+++ b/spec/gloas/executionpayloadheader.go
@@ -42,6 +42,7 @@ type ExecutionPayloadHeader struct {
 	BlobGasUsed         uint64
 	ExcessBlobGas       uint64
 	BlockAccessListRoot phase0.Root `ssz-size:"32"`
+	SlotNumber          uint64
 }
 
 // String returns a string version of the structure.

--- a/spec/gloas/executionpayloadheader_json.go
+++ b/spec/gloas/executionpayloadheader_json.go
@@ -47,6 +47,7 @@ type executionPayloadHeaderJSON struct {
 	BlobGasUsed         string                     `json:"blob_gas_used"`
 	ExcessBlobGas       string                     `json:"excess_blob_gas"`
 	BlockAccessListRoot phase0.Root                `json:"block_access_list_root"`
+	SlotNumber          string                     `json:"slot_number"`
 }
 
 // MarshalJSON implements json.Marshaler.
@@ -75,6 +76,7 @@ func (e *ExecutionPayloadHeader) MarshalJSON() ([]byte, error) {
 		BlobGasUsed:         strconv.FormatUint(e.BlobGasUsed, 10),
 		ExcessBlobGas:       strconv.FormatUint(e.ExcessBlobGas, 10),
 		BlockAccessListRoot: e.BlockAccessListRoot,
+		SlotNumber:          strconv.FormatUint(e.SlotNumber, 10),
 	})
 }
 
@@ -219,6 +221,12 @@ func (e *ExecutionPayloadHeader) UnmarshalJSON(input []byte) error {
 	if err := e.BlockAccessListRoot.UnmarshalJSON(raw["block_access_list_root"]); err != nil {
 		return errors.Wrap(err, "block_access_list_root")
 	}
+
+	tmpUint, err = strconv.ParseUint(string(bytes.Trim(raw["slot_number"], `"`)), 10, 64)
+	if err != nil {
+		return errors.Wrap(err, "slot_number")
+	}
+	e.SlotNumber = tmpUint
 
 	return nil
 }

--- a/spec/gloas/executionpayloadheader_ssz.go
+++ b/spec/gloas/executionpayloadheader_ssz.go
@@ -16,7 +16,7 @@ func (e *ExecutionPayloadHeader) MarshalSSZ() ([]byte, error) {
 // MarshalSSZTo ssz marshals the ExecutionPayloadHeader object to a target array
 func (e *ExecutionPayloadHeader) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	dst = buf
-	offset := int(616)
+	offset := int(624)
 
 	// Field (0) 'ParentHash'
 	dst = append(dst, e.ParentHash[:]...)
@@ -76,6 +76,9 @@ func (e *ExecutionPayloadHeader) MarshalSSZTo(buf []byte) (dst []byte, err error
 	// Field (17) 'BlockAccessListRoot'
 	dst = append(dst, e.BlockAccessListRoot[:]...)
 
+	// Field (18) 'SlotNumber'
+	dst = ssz.MarshalUint64(dst, e.SlotNumber)
+
 	// Field (10) 'ExtraData'
 	if size := len(e.ExtraData); size > 32 {
 		err = ssz.ErrBytesLengthFn("ExecutionPayloadHeader.ExtraData", size, 32)
@@ -90,7 +93,7 @@ func (e *ExecutionPayloadHeader) MarshalSSZTo(buf []byte) (dst []byte, err error
 func (e *ExecutionPayloadHeader) UnmarshalSSZ(buf []byte) error {
 	var err error
 	size := uint64(len(buf))
-	if size < 616 {
+	if size < 624 {
 		return ssz.ErrSize
 	}
 
@@ -132,7 +135,7 @@ func (e *ExecutionPayloadHeader) UnmarshalSSZ(buf []byte) error {
 		return ssz.ErrOffset
 	}
 
-	if o10 < 616 {
+	if o10 < 624 {
 		return ssz.ErrInvalidVariableOffset
 	}
 
@@ -162,6 +165,9 @@ func (e *ExecutionPayloadHeader) UnmarshalSSZ(buf []byte) error {
 	// Field (17) 'BlockAccessListRoot'
 	copy(e.BlockAccessListRoot[:], buf[584:616])
 
+	// Field (18) 'SlotNumber'
+	e.SlotNumber = ssz.UnmarshallUint64(buf[616:624])
+
 	// Field (10) 'ExtraData'
 	{
 		buf = tail[o10:]
@@ -178,7 +184,7 @@ func (e *ExecutionPayloadHeader) UnmarshalSSZ(buf []byte) error {
 
 // SizeSSZ returns the ssz encoded size in bytes for the ExecutionPayloadHeader object
 func (e *ExecutionPayloadHeader) SizeSSZ() (size int) {
-	size = 616
+	size = 624
 
 	// Field (10) 'ExtraData'
 	size += len(e.ExtraData)
@@ -262,6 +268,9 @@ func (e *ExecutionPayloadHeader) HashTreeRootWith(hh ssz.HashWalker) (err error)
 
 	// Field (17) 'BlockAccessListRoot'
 	hh.PutBytes(e.BlockAccessListRoot[:])
+
+	// Field (18) 'SlotNumber'
+	hh.PutUint64(e.SlotNumber)
 
 	hh.Merkleize(indx)
 	return

--- a/spec/gloas/executionpayloadheader_yaml.go
+++ b/spec/gloas/executionpayloadheader_yaml.go
@@ -44,6 +44,7 @@ type executionPayloadHeaderYAML struct {
 	BlobGasUsed         uint64                     `yaml:"blob_gas_used"`
 	ExcessBlobGas       uint64                     `yaml:"excess_blob_gas"`
 	BlockAccessListRoot phase0.Root                `yaml:"block_access_list_root"`
+	SlotNumber          uint64                     `yaml:"slot_number"`
 }
 
 // MarshalYAML implements yaml.Marshaler.
@@ -72,6 +73,7 @@ func (e *ExecutionPayloadHeader) MarshalYAML() ([]byte, error) {
 		BlobGasUsed:         e.BlobGasUsed,
 		ExcessBlobGas:       e.ExcessBlobGas,
 		BlockAccessListRoot: e.BlockAccessListRoot,
+		SlotNumber:          e.SlotNumber,
 	}, yaml.Flow(true))
 	if err != nil {
 		return nil, err

--- a/spec/versionedexecutionpayload.go
+++ b/spec/versionedexecutionpayload.go
@@ -865,6 +865,34 @@ func (v *VersionedExecutionPayload) BlockAccessList() (gloas.BlockAccessList, er
 	}
 }
 
+// SlotNumber returns the slot number of the execution payload.
+func (v *VersionedExecutionPayload) SlotNumber() (uint64, error) {
+	switch v.Version {
+	case DataVersionPhase0:
+		return 0, errors.New("no execution payload in phase0")
+	case DataVersionAltair:
+		return 0, errors.New("no execution payload in altair")
+	case DataVersionBellatrix:
+		return 0, errors.New("no slot number in bellatrix")
+	case DataVersionCapella:
+		return 0, errors.New("no slot number in capella")
+	case DataVersionDeneb:
+		return 0, errors.New("no slot number in deneb")
+	case DataVersionElectra:
+		return 0, errors.New("no slot number in electra")
+	case DataVersionFulu:
+		return 0, errors.New("no slot number in fulu")
+	case DataVersionGloas:
+		if v.Gloas == nil {
+			return 0, errors.New("no gloas execution payload")
+		}
+
+		return v.Gloas.SlotNumber, nil
+	default:
+		return 0, errors.New("unknown version")
+	}
+}
+
 // String returns a string version of the structure.
 func (v *VersionedExecutionPayload) String() string {
 	switch v.Version {


### PR DESCRIPTION
## Summary
- Adds `SlotNumber uint64` field to Gloas `ExecutionPayload` and `ExecutionPayloadHeader` (EIP-7843)
- Updates JSON, YAML, and SSZ serialization for both types
- Adds `SlotNumber()` getter to `VersionedExecutionPayload`

This is needed for bal-devnet-2 checkpoint sync — the checkpointz service can't deserialize post-Gloas blocks without this field, causing the serving bundle to be stuck at epoch 31 (pre-Gloas).

## Test plan
- [x] `go build ./...` passes
- [ ] Verify checkpointz can parse bal-devnet-2 Gloas blocks after updating dependency

🤖 Generated with [Claude Code](https://claude.com/claude-code)