### PR TITLE
add VersionedExecutionPayloadEnvelope

### DIFF
--- a/http/signedexecutionpayloadenvelope.go
+++ b/http/signedexecutionpayloadenvelope.go
@@ -30,7 +30,7 @@ import (
 func (s *Service) SignedExecutionPayloadEnvelope(ctx context.Context,
 	opts *api.SignedExecutionPayloadEnvelopeOpts,
 ) (
-	*api.Response[*gloas.SignedExecutionPayloadEnvelope],
+	*api.Response[*spec.VersionedSignedExecutionPayloadEnvelope],
 	error,
 ) {
 	if err := s.assertIsActive(ctx); err != nil {
@@ -49,7 +49,7 @@ func (s *Service) SignedExecutionPayloadEnvelope(ctx context.Context,
 		return nil, err
 	}
 
-	var response *api.Response[*gloas.SignedExecutionPayloadEnvelope]
+	var response *api.Response[*spec.VersionedSignedExecutionPayloadEnvelope]
 	switch httpResponse.contentType {
 	case ContentTypeSSZ:
 		response, err = s.signedExecutionPayloadEnvelopeFromSSZ(ctx, httpResponse)
@@ -68,10 +68,17 @@ func (s *Service) SignedExecutionPayloadEnvelope(ctx context.Context,
 func (s *Service) signedExecutionPayloadEnvelopeFromSSZ(ctx context.Context,
 	res *httpResponse,
 ) (
-	*api.Response[*gloas.SignedExecutionPayloadEnvelope],
+	*api.Response[*spec.VersionedSignedExecutionPayloadEnvelope],
 	error,
 ) {
-	response := &api.Response[*gloas.SignedExecutionPayloadEnvelope]{
+	if res.consensusVersion != spec.DataVersionGloas && res.consensusVersion != spec.DataVersionHeze {
+		return nil, fmt.Errorf("execution payload envelope not available for block version %s", res.consensusVersion)
+	}
+
+	response := &api.Response[*spec.VersionedSignedExecutionPayloadEnvelope]{
+		Data: &spec.VersionedSignedExecutionPayloadEnvelope{
+			Version: res.consensusVersion,
+		},
 		Metadata: metadataFromHeaders(res.headers),
 	}
 
@@ -85,41 +92,43 @@ func (s *Service) signedExecutionPayloadEnvelopeFromSSZ(ctx context.Context,
 		dynSSZ = dynssz.NewDynSsz(specs.Data)
 	}
 
-	if res.consensusVersion != spec.DataVersionGloas && res.consensusVersion != spec.DataVersionHeze {
-		return nil, fmt.Errorf("execution payload envelope not available for block version %s", res.consensusVersion)
-	}
+	envelope := &gloas.SignedExecutionPayloadEnvelope{}
 
 	var err error
-	response.Data = &gloas.SignedExecutionPayloadEnvelope{}
 	if s.customSpecSupport {
-		err = dynSSZ.UnmarshalSSZ(response.Data, res.body)
+		err = dynSSZ.UnmarshalSSZ(envelope, res.body)
 	} else {
-		err = response.Data.UnmarshalSSZ(res.body)
+		err = envelope.UnmarshalSSZ(res.body)
 	}
 	if err != nil {
 		return nil, errors.Join(errors.New("failed to decode gloas signed execution payload envelope contents"), err)
 	}
 
+	response.Data.Gloas = envelope
+
 	return response, nil
 }
 
 func (*Service) signedExecutionPayloadEnvelopeFromJSON(res *httpResponse) (
-	*api.Response[*gloas.SignedExecutionPayloadEnvelope],
+	*api.Response[*spec.VersionedSignedExecutionPayloadEnvelope],
 	error,
 ) {
-	response := &api.Response[*gloas.SignedExecutionPayloadEnvelope]{}
-
 	if res.consensusVersion != spec.DataVersionGloas && res.consensusVersion != spec.DataVersionHeze {
 		return nil, fmt.Errorf("execution payload envelope not available for block version %s", res.consensusVersion)
 	}
 
-	var err error
-	response.Data, response.Metadata, err = decodeJSONResponse(bytes.NewReader(res.body),
+	envelope, metadata, err := decodeJSONResponse(bytes.NewReader(res.body),
 		&gloas.SignedExecutionPayloadEnvelope{},
 	)
 	if err != nil {
 		return nil, err
 	}
 
-	return response, nil
+	return &api.Response[*spec.VersionedSignedExecutionPayloadEnvelope]{
+		Data: &spec.VersionedSignedExecutionPayloadEnvelope{
+			Version: res.consensusVersion,
+			Gloas:   envelope,
+		},
+		Metadata: metadata,
+	}, nil
 }

--- a/mock/service.go
+++ b/mock/service.go
@@ -22,7 +22,6 @@ import (
 	"github.com/ethpandaops/go-eth2-client/spec"
 	"github.com/ethpandaops/go-eth2-client/spec/altair"
 	"github.com/ethpandaops/go-eth2-client/spec/electra"
-	"github.com/ethpandaops/go-eth2-client/spec/gloas"
 	"github.com/ethpandaops/go-eth2-client/spec/phase0"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
@@ -77,7 +76,7 @@ type Service struct {
 	ProposalFunc                       func(context.Context, *api.ProposalOpts) (*api.Response[*api.VersionedProposal], error)
 	ProposerDutiesFunc                 func(context.Context, *api.ProposerDutiesOpts) (*api.Response[[]*apiv1.ProposerDuty], error)
 	SignedBeaconBlockFunc              func(context.Context, *api.SignedBeaconBlockOpts) (*api.Response[*spec.VersionedSignedBeaconBlock], error)
-	SignedExecutionPayloadEnvelopeFunc func(context.Context, *api.SignedExecutionPayloadEnvelopeOpts) (*api.Response[*gloas.SignedExecutionPayloadEnvelope], error)
+	SignedExecutionPayloadEnvelopeFunc func(context.Context, *api.SignedExecutionPayloadEnvelopeOpts) (*api.Response[*spec.VersionedSignedExecutionPayloadEnvelope], error)
 	SpecFunc                           func(context.Context, *api.SpecOpts) (*api.Response[map[string]any], error)
 	SyncCommitteeContributionFunc      func(context.Context, *api.SyncCommitteeContributionOpts) (*api.Response[*altair.SyncCommitteeContribution], error)
 	SyncCommitteeDutiesFunc            func(context.Context, *api.SyncCommitteeDutiesOpts) (*api.Response[[]*apiv1.SyncCommitteeDuty], error)

--- a/mock/signedexecutionpayloadenvelope.go
+++ b/mock/signedexecutionpayloadenvelope.go
@@ -17,6 +17,7 @@ import (
 	"context"
 
 	"github.com/ethpandaops/go-eth2-client/api"
+	"github.com/ethpandaops/go-eth2-client/spec"
 	"github.com/ethpandaops/go-eth2-client/spec/bellatrix"
 	"github.com/ethpandaops/go-eth2-client/spec/capella"
 	"github.com/ethpandaops/go-eth2-client/spec/electra"
@@ -27,24 +28,27 @@ import (
 func (s *Service) SignedExecutionPayloadEnvelope(ctx context.Context,
 	opts *api.SignedExecutionPayloadEnvelopeOpts,
 ) (
-	*api.Response[*gloas.SignedExecutionPayloadEnvelope],
+	*api.Response[*spec.VersionedSignedExecutionPayloadEnvelope],
 	error,
 ) {
 	if s.SignedExecutionPayloadEnvelopeFunc != nil {
 		return s.SignedExecutionPayloadEnvelopeFunc(ctx, opts)
 	}
 
-	return &api.Response[*gloas.SignedExecutionPayloadEnvelope]{
-		Data: &gloas.SignedExecutionPayloadEnvelope{
-			Message: &gloas.ExecutionPayloadEnvelope{
-				Payload: &gloas.ExecutionPayload{
-					Transactions: []bellatrix.Transaction{},
-					Withdrawals:  []*capella.Withdrawal{},
-				},
-				ExecutionRequests: &electra.ExecutionRequests{
-					Deposits:       []*electra.DepositRequest{},
-					Withdrawals:    []*electra.WithdrawalRequest{},
-					Consolidations: []*electra.ConsolidationRequest{},
+	return &api.Response[*spec.VersionedSignedExecutionPayloadEnvelope]{
+		Data: &spec.VersionedSignedExecutionPayloadEnvelope{
+			Version: spec.DataVersionGloas,
+			Gloas: &gloas.SignedExecutionPayloadEnvelope{
+				Message: &gloas.ExecutionPayloadEnvelope{
+					Payload: &gloas.ExecutionPayload{
+						Transactions: []bellatrix.Transaction{},
+						Withdrawals:  []*capella.Withdrawal{},
+					},
+					ExecutionRequests: &electra.ExecutionRequests{
+						Deposits:       []*electra.DepositRequest{},
+						Withdrawals:    []*electra.WithdrawalRequest{},
+						Consolidations: []*electra.ConsolidationRequest{},
+					},
 				},
 			},
 		},

--- a/multi/signedexecutionpayloadenvelope.go
+++ b/multi/signedexecutionpayloadenvelope.go
@@ -18,14 +18,14 @@ import (
 
 	consensusclient "github.com/ethpandaops/go-eth2-client"
 	"github.com/ethpandaops/go-eth2-client/api"
-	"github.com/ethpandaops/go-eth2-client/spec/gloas"
+	"github.com/ethpandaops/go-eth2-client/spec"
 )
 
 // SignedExecutionPayloadEnvelope fetches a signed execution payload envelope given a block ID.
 func (s *Service) SignedExecutionPayloadEnvelope(ctx context.Context,
 	opts *api.SignedExecutionPayloadEnvelopeOpts,
 ) (
-	*api.Response[*gloas.SignedExecutionPayloadEnvelope],
+	*api.Response[*spec.VersionedSignedExecutionPayloadEnvelope],
 	error,
 ) {
 	res, err := s.doCall(ctx, func(ctx context.Context, client consensusclient.Service) (any, error) {
@@ -40,7 +40,7 @@ func (s *Service) SignedExecutionPayloadEnvelope(ctx context.Context,
 		return nil, err
 	}
 
-	response, isResponse := res.(*api.Response[*gloas.SignedExecutionPayloadEnvelope])
+	response, isResponse := res.(*api.Response[*spec.VersionedSignedExecutionPayloadEnvelope])
 	if !isResponse {
 		return nil, ErrIncorrectType
 	}

--- a/service.go
+++ b/service.go
@@ -24,7 +24,6 @@ import (
 	"github.com/ethpandaops/go-eth2-client/spec/capella"
 	"github.com/ethpandaops/go-eth2-client/spec/deneb"
 	"github.com/ethpandaops/go-eth2-client/spec/electra"
-	"github.com/ethpandaops/go-eth2-client/spec/gloas"
 	"github.com/ethpandaops/go-eth2-client/spec/phase0"
 )
 
@@ -626,11 +625,13 @@ type VoluntaryExitPoolProvider interface {
 
 // ExecutionPayloadProvider is the interface for providing execution payloads.
 type ExecutionPayloadProvider interface {
-	// SignedBeaconBlock fetches a signed beacon block given a block ID.
+	// SignedExecutionPayloadEnvelope fetches a signed execution payload
+	// envelope given a block ID. Returns a versioned wrapper so callers can
+	// branch on Version regardless of which fork's envelope is populated.
 	SignedExecutionPayloadEnvelope(ctx context.Context,
 		opts *api.SignedExecutionPayloadEnvelopeOpts,
 	) (
-		*api.Response[*gloas.SignedExecutionPayloadEnvelope],
+		*api.Response[*spec.VersionedSignedExecutionPayloadEnvelope],
 		error,
 	)
 }

--- a/spec/versionedexecutionpayloadenvelope.go
+++ b/spec/versionedexecutionpayloadenvelope.go
@@ -1,0 +1,192 @@
+// Copyright © 2026 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spec
+
+import (
+	"errors"
+
+	"github.com/ethpandaops/go-eth2-client/spec/electra"
+	"github.com/ethpandaops/go-eth2-client/spec/gloas"
+	"github.com/ethpandaops/go-eth2-client/spec/phase0"
+)
+
+// VersionedExecutionPayloadEnvelope contains a versioned execution payload
+// envelope (EIP-7732). The envelope is a gloas-onwards container; this
+// wrapper exists so callers can treat it uniformly with other versioned types.
+type VersionedExecutionPayloadEnvelope struct {
+	Version DataVersion
+	Gloas   *gloas.ExecutionPayloadEnvelope
+}
+
+// IsEmpty returns true if no fork-specific envelope is populated.
+func (v *VersionedExecutionPayloadEnvelope) IsEmpty() bool {
+	return v.Gloas == nil
+}
+
+// String returns a string version of the structure.
+func (v *VersionedExecutionPayloadEnvelope) String() string {
+	switch v.Version {
+	case DataVersionPhase0, DataVersionAltair, DataVersionBellatrix, DataVersionCapella,
+		DataVersionDeneb, DataVersionElectra, DataVersionFulu:
+		return ""
+	case DataVersionGloas:
+		if v.Gloas == nil {
+			return ""
+		}
+
+		return v.Gloas.String()
+	default:
+		return "unknown version"
+	}
+}
+
+// Payload returns the execution payload of the envelope.
+func (v *VersionedExecutionPayloadEnvelope) Payload() (*gloas.ExecutionPayload, error) {
+	switch v.Version {
+	case DataVersionPhase0:
+		return nil, errors.New("no execution payload envelope in phase0")
+	case DataVersionAltair:
+		return nil, errors.New("no execution payload envelope in altair")
+	case DataVersionBellatrix:
+		return nil, errors.New("no execution payload envelope in bellatrix")
+	case DataVersionCapella:
+		return nil, errors.New("no execution payload envelope in capella")
+	case DataVersionDeneb:
+		return nil, errors.New("no execution payload envelope in deneb")
+	case DataVersionElectra:
+		return nil, errors.New("no execution payload envelope in electra")
+	case DataVersionFulu:
+		return nil, errors.New("no execution payload envelope in fulu")
+	case DataVersionGloas:
+		if v.Gloas == nil {
+			return nil, errors.New("no gloas execution payload envelope")
+		}
+
+		return v.Gloas.Payload, nil
+	default:
+		return nil, errors.New("unknown version")
+	}
+}
+
+// ExecutionRequests returns the execution requests of the envelope.
+func (v *VersionedExecutionPayloadEnvelope) ExecutionRequests() (*electra.ExecutionRequests, error) {
+	switch v.Version {
+	case DataVersionPhase0:
+		return nil, errors.New("no execution payload envelope in phase0")
+	case DataVersionAltair:
+		return nil, errors.New("no execution payload envelope in altair")
+	case DataVersionBellatrix:
+		return nil, errors.New("no execution payload envelope in bellatrix")
+	case DataVersionCapella:
+		return nil, errors.New("no execution payload envelope in capella")
+	case DataVersionDeneb:
+		return nil, errors.New("no execution payload envelope in deneb")
+	case DataVersionElectra:
+		return nil, errors.New("no execution payload envelope in electra")
+	case DataVersionFulu:
+		return nil, errors.New("no execution payload envelope in fulu")
+	case DataVersionGloas:
+		if v.Gloas == nil {
+			return nil, errors.New("no gloas execution payload envelope")
+		}
+
+		return v.Gloas.ExecutionRequests, nil
+	default:
+		return nil, errors.New("unknown version")
+	}
+}
+
+// BuilderIndex returns the builder index of the envelope.
+func (v *VersionedExecutionPayloadEnvelope) BuilderIndex() (gloas.BuilderIndex, error) {
+	switch v.Version {
+	case DataVersionPhase0:
+		return 0, errors.New("no execution payload envelope in phase0")
+	case DataVersionAltair:
+		return 0, errors.New("no execution payload envelope in altair")
+	case DataVersionBellatrix:
+		return 0, errors.New("no execution payload envelope in bellatrix")
+	case DataVersionCapella:
+		return 0, errors.New("no execution payload envelope in capella")
+	case DataVersionDeneb:
+		return 0, errors.New("no execution payload envelope in deneb")
+	case DataVersionElectra:
+		return 0, errors.New("no execution payload envelope in electra")
+	case DataVersionFulu:
+		return 0, errors.New("no execution payload envelope in fulu")
+	case DataVersionGloas:
+		if v.Gloas == nil {
+			return 0, errors.New("no gloas execution payload envelope")
+		}
+
+		return v.Gloas.BuilderIndex, nil
+	default:
+		return 0, errors.New("unknown version")
+	}
+}
+
+// BeaconBlockRoot returns the beacon block root of the envelope.
+func (v *VersionedExecutionPayloadEnvelope) BeaconBlockRoot() (phase0.Root, error) {
+	switch v.Version {
+	case DataVersionPhase0:
+		return phase0.Root{}, errors.New("no execution payload envelope in phase0")
+	case DataVersionAltair:
+		return phase0.Root{}, errors.New("no execution payload envelope in altair")
+	case DataVersionBellatrix:
+		return phase0.Root{}, errors.New("no execution payload envelope in bellatrix")
+	case DataVersionCapella:
+		return phase0.Root{}, errors.New("no execution payload envelope in capella")
+	case DataVersionDeneb:
+		return phase0.Root{}, errors.New("no execution payload envelope in deneb")
+	case DataVersionElectra:
+		return phase0.Root{}, errors.New("no execution payload envelope in electra")
+	case DataVersionFulu:
+		return phase0.Root{}, errors.New("no execution payload envelope in fulu")
+	case DataVersionGloas:
+		if v.Gloas == nil {
+			return phase0.Root{}, errors.New("no gloas execution payload envelope")
+		}
+
+		return v.Gloas.BeaconBlockRoot, nil
+	default:
+		return phase0.Root{}, errors.New("unknown version")
+	}
+}
+
+// ParentBeaconBlockRoot returns the parent beacon block root of the envelope.
+func (v *VersionedExecutionPayloadEnvelope) ParentBeaconBlockRoot() (phase0.Root, error) {
+	switch v.Version {
+	case DataVersionPhase0:
+		return phase0.Root{}, errors.New("no execution payload envelope in phase0")
+	case DataVersionAltair:
+		return phase0.Root{}, errors.New("no execution payload envelope in altair")
+	case DataVersionBellatrix:
+		return phase0.Root{}, errors.New("no execution payload envelope in bellatrix")
+	case DataVersionCapella:
+		return phase0.Root{}, errors.New("no execution payload envelope in capella")
+	case DataVersionDeneb:
+		return phase0.Root{}, errors.New("no execution payload envelope in deneb")
+	case DataVersionElectra:
+		return phase0.Root{}, errors.New("no execution payload envelope in electra")
+	case DataVersionFulu:
+		return phase0.Root{}, errors.New("no execution payload envelope in fulu")
+	case DataVersionGloas:
+		if v.Gloas == nil {
+			return phase0.Root{}, errors.New("no gloas execution payload envelope")
+		}
+
+		return v.Gloas.ParentBeaconBlockRoot, nil
+	default:
+		return phase0.Root{}, errors.New("unknown version")
+	}
+}

--- a/spec/versionedsignedexecutionpayloadenvelope.go
+++ b/spec/versionedsignedexecutionpayloadenvelope.go
@@ -1,0 +1,249 @@
+// Copyright © 2026 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spec
+
+import (
+	"errors"
+
+	"github.com/ethpandaops/go-eth2-client/spec/electra"
+	"github.com/ethpandaops/go-eth2-client/spec/gloas"
+	"github.com/ethpandaops/go-eth2-client/spec/phase0"
+)
+
+// VersionedSignedExecutionPayloadEnvelope contains a versioned signed
+// execution payload envelope (EIP-7732). The envelope is a gloas-onwards
+// container; this wrapper exists so callers can treat it uniformly with
+// other versioned types.
+type VersionedSignedExecutionPayloadEnvelope struct {
+	Version DataVersion
+	Gloas   *gloas.SignedExecutionPayloadEnvelope
+}
+
+// IsEmpty returns true if no fork-specific envelope is populated.
+func (v *VersionedSignedExecutionPayloadEnvelope) IsEmpty() bool {
+	return v.Gloas == nil
+}
+
+// String returns a string version of the structure.
+func (v *VersionedSignedExecutionPayloadEnvelope) String() string {
+	switch v.Version {
+	case DataVersionPhase0, DataVersionAltair, DataVersionBellatrix, DataVersionCapella,
+		DataVersionDeneb, DataVersionElectra, DataVersionFulu:
+		return ""
+	case DataVersionGloas:
+		if v.Gloas == nil {
+			return ""
+		}
+
+		return v.Gloas.String()
+	default:
+		return "unknown version"
+	}
+}
+
+// Message returns the inner ExecutionPayloadEnvelope.
+func (v *VersionedSignedExecutionPayloadEnvelope) Message() (*gloas.ExecutionPayloadEnvelope, error) {
+	switch v.Version {
+	case DataVersionPhase0:
+		return nil, errors.New("no execution payload envelope in phase0")
+	case DataVersionAltair:
+		return nil, errors.New("no execution payload envelope in altair")
+	case DataVersionBellatrix:
+		return nil, errors.New("no execution payload envelope in bellatrix")
+	case DataVersionCapella:
+		return nil, errors.New("no execution payload envelope in capella")
+	case DataVersionDeneb:
+		return nil, errors.New("no execution payload envelope in deneb")
+	case DataVersionElectra:
+		return nil, errors.New("no execution payload envelope in electra")
+	case DataVersionFulu:
+		return nil, errors.New("no execution payload envelope in fulu")
+	case DataVersionGloas:
+		if v.Gloas == nil || v.Gloas.Message == nil {
+			return nil, errors.New("no gloas signed execution payload envelope")
+		}
+
+		return v.Gloas.Message, nil
+	default:
+		return nil, errors.New("unknown version")
+	}
+}
+
+// Payload returns the execution payload contained in the signed envelope.
+func (v *VersionedSignedExecutionPayloadEnvelope) Payload() (*gloas.ExecutionPayload, error) {
+	switch v.Version {
+	case DataVersionPhase0:
+		return nil, errors.New("no execution payload envelope in phase0")
+	case DataVersionAltair:
+		return nil, errors.New("no execution payload envelope in altair")
+	case DataVersionBellatrix:
+		return nil, errors.New("no execution payload envelope in bellatrix")
+	case DataVersionCapella:
+		return nil, errors.New("no execution payload envelope in capella")
+	case DataVersionDeneb:
+		return nil, errors.New("no execution payload envelope in deneb")
+	case DataVersionElectra:
+		return nil, errors.New("no execution payload envelope in electra")
+	case DataVersionFulu:
+		return nil, errors.New("no execution payload envelope in fulu")
+	case DataVersionGloas:
+		if v.Gloas == nil || v.Gloas.Message == nil {
+			return nil, errors.New("no gloas signed execution payload envelope")
+		}
+
+		return v.Gloas.Message.Payload, nil
+	default:
+		return nil, errors.New("unknown version")
+	}
+}
+
+// ExecutionRequests returns the execution requests contained in the signed envelope.
+func (v *VersionedSignedExecutionPayloadEnvelope) ExecutionRequests() (*electra.ExecutionRequests, error) {
+	switch v.Version {
+	case DataVersionPhase0:
+		return nil, errors.New("no execution payload envelope in phase0")
+	case DataVersionAltair:
+		return nil, errors.New("no execution payload envelope in altair")
+	case DataVersionBellatrix:
+		return nil, errors.New("no execution payload envelope in bellatrix")
+	case DataVersionCapella:
+		return nil, errors.New("no execution payload envelope in capella")
+	case DataVersionDeneb:
+		return nil, errors.New("no execution payload envelope in deneb")
+	case DataVersionElectra:
+		return nil, errors.New("no execution payload envelope in electra")
+	case DataVersionFulu:
+		return nil, errors.New("no execution payload envelope in fulu")
+	case DataVersionGloas:
+		if v.Gloas == nil || v.Gloas.Message == nil {
+			return nil, errors.New("no gloas signed execution payload envelope")
+		}
+
+		return v.Gloas.Message.ExecutionRequests, nil
+	default:
+		return nil, errors.New("unknown version")
+	}
+}
+
+// BuilderIndex returns the builder index of the signed envelope.
+func (v *VersionedSignedExecutionPayloadEnvelope) BuilderIndex() (gloas.BuilderIndex, error) {
+	switch v.Version {
+	case DataVersionPhase0:
+		return 0, errors.New("no execution payload envelope in phase0")
+	case DataVersionAltair:
+		return 0, errors.New("no execution payload envelope in altair")
+	case DataVersionBellatrix:
+		return 0, errors.New("no execution payload envelope in bellatrix")
+	case DataVersionCapella:
+		return 0, errors.New("no execution payload envelope in capella")
+	case DataVersionDeneb:
+		return 0, errors.New("no execution payload envelope in deneb")
+	case DataVersionElectra:
+		return 0, errors.New("no execution payload envelope in electra")
+	case DataVersionFulu:
+		return 0, errors.New("no execution payload envelope in fulu")
+	case DataVersionGloas:
+		if v.Gloas == nil || v.Gloas.Message == nil {
+			return 0, errors.New("no gloas signed execution payload envelope")
+		}
+
+		return v.Gloas.Message.BuilderIndex, nil
+	default:
+		return 0, errors.New("unknown version")
+	}
+}
+
+// BeaconBlockRoot returns the beacon block root of the signed envelope.
+func (v *VersionedSignedExecutionPayloadEnvelope) BeaconBlockRoot() (phase0.Root, error) {
+	switch v.Version {
+	case DataVersionPhase0:
+		return phase0.Root{}, errors.New("no execution payload envelope in phase0")
+	case DataVersionAltair:
+		return phase0.Root{}, errors.New("no execution payload envelope in altair")
+	case DataVersionBellatrix:
+		return phase0.Root{}, errors.New("no execution payload envelope in bellatrix")
+	case DataVersionCapella:
+		return phase0.Root{}, errors.New("no execution payload envelope in capella")
+	case DataVersionDeneb:
+		return phase0.Root{}, errors.New("no execution payload envelope in deneb")
+	case DataVersionElectra:
+		return phase0.Root{}, errors.New("no execution payload envelope in electra")
+	case DataVersionFulu:
+		return phase0.Root{}, errors.New("no execution payload envelope in fulu")
+	case DataVersionGloas:
+		if v.Gloas == nil || v.Gloas.Message == nil {
+			return phase0.Root{}, errors.New("no gloas signed execution payload envelope")
+		}
+
+		return v.Gloas.Message.BeaconBlockRoot, nil
+	default:
+		return phase0.Root{}, errors.New("unknown version")
+	}
+}
+
+// ParentBeaconBlockRoot returns the parent beacon block root of the signed envelope.
+func (v *VersionedSignedExecutionPayloadEnvelope) ParentBeaconBlockRoot() (phase0.Root, error) {
+	switch v.Version {
+	case DataVersionPhase0:
+		return phase0.Root{}, errors.New("no execution payload envelope in phase0")
+	case DataVersionAltair:
+		return phase0.Root{}, errors.New("no execution payload envelope in altair")
+	case DataVersionBellatrix:
+		return phase0.Root{}, errors.New("no execution payload envelope in bellatrix")
+	case DataVersionCapella:
+		return phase0.Root{}, errors.New("no execution payload envelope in capella")
+	case DataVersionDeneb:
+		return phase0.Root{}, errors.New("no execution payload envelope in deneb")
+	case DataVersionElectra:
+		return phase0.Root{}, errors.New("no execution payload envelope in electra")
+	case DataVersionFulu:
+		return phase0.Root{}, errors.New("no execution payload envelope in fulu")
+	case DataVersionGloas:
+		if v.Gloas == nil || v.Gloas.Message == nil {
+			return phase0.Root{}, errors.New("no gloas signed execution payload envelope")
+		}
+
+		return v.Gloas.Message.ParentBeaconBlockRoot, nil
+	default:
+		return phase0.Root{}, errors.New("unknown version")
+	}
+}
+
+// Signature returns the signature on the envelope.
+func (v *VersionedSignedExecutionPayloadEnvelope) Signature() (phase0.BLSSignature, error) {
+	switch v.Version {
+	case DataVersionPhase0:
+		return phase0.BLSSignature{}, errors.New("no execution payload envelope in phase0")
+	case DataVersionAltair:
+		return phase0.BLSSignature{}, errors.New("no execution payload envelope in altair")
+	case DataVersionBellatrix:
+		return phase0.BLSSignature{}, errors.New("no execution payload envelope in bellatrix")
+	case DataVersionCapella:
+		return phase0.BLSSignature{}, errors.New("no execution payload envelope in capella")
+	case DataVersionDeneb:
+		return phase0.BLSSignature{}, errors.New("no execution payload envelope in deneb")
+	case DataVersionElectra:
+		return phase0.BLSSignature{}, errors.New("no execution payload envelope in electra")
+	case DataVersionFulu:
+		return phase0.BLSSignature{}, errors.New("no execution payload envelope in fulu")
+	case DataVersionGloas:
+		if v.Gloas == nil {
+			return phase0.BLSSignature{}, errors.New("no gloas signed execution payload envelope")
+		}
+
+		return v.Gloas.Signature, nil
+	default:
+		return phase0.BLSSignature{}, errors.New("unknown version")
+	}
+}

--- a/util/proof/proofs.go
+++ b/util/proof/proofs.go
@@ -89,7 +89,7 @@ func NumFields(o any) int {
 	t := reflect.TypeOf(o)
 
 	// If it's a pointer, get the underlying type
-	if t.Kind() == reflect.Ptr {
+	if t.Kind() == reflect.Pointer {
 		t = t.Elem()
 	}
 
@@ -111,7 +111,7 @@ func FieldIndex(o any, fieldName string) (int, error) {
 	t := reflect.TypeOf(o)
 
 	// If it's a pointer, get the underlying type
-	if t.Kind() == reflect.Ptr {
+	if t.Kind() == reflect.Pointer {
 		t = t.Elem()
 	}
 


### PR DESCRIPTION
# Add `VersionedExecutionPayloadEnvelope` and `VersionedSignedExecutionPayloadEnvelope`

## Summary

Adds versioned wrappers for the EIP-7732 execution payload envelope and signed
execution payload envelope, mirroring the existing `Versioned*` pattern used
across the rest of the spec package. Switches the `ExecutionPayloadProvider`
interface and its implementations (`http`, `multi`, `mock`) to return the
versioned wrappers instead of the bare `gloas.SignedExecutionPayloadEnvelope`.

## Motivation

Every other consensus container in this repo is exposed through a `Versioned*`
wrapper (`VersionedSignedBeaconBlock`, `VersionedBeaconState`,
`VersionedSignedExecutionPayloadBid`, …). The execution payload envelope was
the only outlier — `ExecutionPayloadProvider.SignedExecutionPayloadEnvelope`
returned `*gloas.SignedExecutionPayloadEnvelope` directly. That meant:

- Callers had to import the `gloas` package by name even when they didn't care
  which fork the envelope came from.
- A future fork that adds its own envelope variant would force a breaking API
  change.
- The pattern diverged from sibling APIs, which makes generic versioned
  handling (logging, dispatch tables, metrics) inconsistent.

## Changes

### New files

- `spec/versionedexecutionpayloadenvelope.go` — `VersionedExecutionPayloadEnvelope`
  with `Version`, `Gloas` field, `IsEmpty`, `String`, and accessors:
  `Payload`, `ExecutionRequests`, `BuilderIndex`, `BeaconBlockRoot`,
  `ParentBeaconBlockRoot`. Each accessor returns an error for forks where the
  envelope doesn't apply.

- `spec/versionedsignedexecutionpayloadenvelope.go` — `VersionedSignedExecutionPayloadEnvelope`
  with `Version`, `Gloas`, `IsEmpty`, `String`, and accessors: `Message`,
  `Payload`, `ExecutionRequests`, `BuilderIndex`, `BeaconBlockRoot`,
  `ParentBeaconBlockRoot`, `Signature`.

Both wrappers contain only a `Gloas` field for now — Heze does not define its
own envelope types yet. When future forks ship their own variant, add the
corresponding field and switch arm exactly the way
`VersionedSignedExecutionPayloadBid` already does for Gloas/Heze.

### Provider interface

`service.go`:

```go
SignedExecutionPayloadEnvelope(ctx, opts) → *api.Response[*spec.VersionedSignedExecutionPayloadEnvelope]
```

(was `*api.Response[*gloas.SignedExecutionPayloadEnvelope]`)

The `gloas` import on `service.go` is now unused and removed.

### Implementations

- `http/signedexecutionpayloadenvelope.go` — both SSZ and JSON paths still
  decode into `*gloas.SignedExecutionPayloadEnvelope` internally (unchanged
  schema), then wrap into the versioned response with `Version: res.consensusVersion`
  (Gloas or Heze) and `Gloas: envelope`. The `Heze` consensus version is
  preserved on the wrapper so callers can distinguish Heze from Gloas even
  though Heze reuses the gloas envelope schema.
- `multi/signedexecutionpayloadenvelope.go` — return-type and assertion swap.
- `mock/signedexecutionpayloadenvelope.go` — stub now produces a versioned
  response with `Version: spec.DataVersionGloas`.
- `mock/service.go` — `SignedExecutionPayloadEnvelopeFunc` signature swap;
  `gloas` import removed (no longer referenced).

### Lint fix

`util/proof/proofs.go` — `reflect.Ptr` → `reflect.Pointer` (the former is
deprecated since Go 1.18 and `golangci-lint` v2.12.2's `govet inline` rule
flags it).

## Backwards compatibility

This is an API-breaking change for anyone calling `SignedExecutionPayloadEnvelope`
directly. The fix is mechanical:

```go
// Before
envelope, err := client.SignedExecutionPayloadEnvelope(ctx, opts)
gloasEnv := envelope.Data           // *gloas.SignedExecutionPayloadEnvelope

// After
envelope, err := client.SignedExecutionPayloadEnvelope(ctx, opts)
gloasEnv := envelope.Data.Gloas     // *gloas.SignedExecutionPayloadEnvelope
// or use the typed accessors:
sig, err := envelope.Data.Signature()
```

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` — all packages pass
- [x] `golangci-lint run ./...` (v2.12.2) — 0 issues
- [ ] Manual sanity check against a Gloas testnet
