### PR TITLE
feat: add fast_confirmation SSE event

### DIFF
--- a/api/eventsopts.go
+++ b/api/eventsopts.go
@@ -64,6 +64,8 @@ type EventsOpts struct {
 	// ExecutionPayloadGossipHandler is a handler for the execution_payload_gossip event
 	// (SignedExecutionPayloadEnvelope passed gossip validation).
 	ExecutionPayloadGossipHandler ExecutionPayloadGossipEventHandlerFunc
+	// FastConfirmationHandler is a handler for the fast_confirmation event.
+	FastConfirmationHandler FastConfirmationEventHandlerFunc
 	// FinalizedCheckpointHandler is a handler for the finalized_checkpoint event.
 	FinalizedCheckpointHandler FinalizedCheckpointEventHandlerFunc
 	// HeadHandler is a handler for the head event.
@@ -141,6 +143,9 @@ type ExecutionPayloadBidEventHandlerFunc func(context.Context, *gloas.SignedExec
 
 // ExecutionPayloadGossipEventHandlerFunc is the handler for execution_payload_gossip events.
 type ExecutionPayloadGossipEventHandlerFunc func(context.Context, *gloas.SignedExecutionPayloadEnvelope)
+
+// FastConfirmationEventHandlerFunc is the handler for fast_confirmation events.
+type FastConfirmationEventHandlerFunc func(context.Context, *apiv1.FastConfirmationEvent)
 
 // PayloadAttestationMessageEventHandlerFunc is the handler for payload_attestation_message events.
 type PayloadAttestationMessageEventHandlerFunc func(context.Context, *gloas.PayloadAttestationMessage)

--- a/api/v1/event.go
+++ b/api/v1/event.go
@@ -49,6 +49,7 @@ var SupportedEventTopics = map[string]bool{
 	"execution_payload_available": true,
 	"execution_payload_bid":       true,
 	"execution_payload_gossip":    true,
+	"fast_confirmation":           true,
 	"finalized_checkpoint":        true,
 	"head":                        true,
 	"inclusion_list":              true,
@@ -129,6 +130,8 @@ func (e *Event) UnmarshalJSON(input []byte) error {
 		e.Data = &ExecutionPayloadAvailableEvent{}
 	case "execution_payload_bid":
 		e.Data = &gloas.SignedExecutionPayloadBid{}
+	case "fast_confirmation":
+		e.Data = &FastConfirmationEvent{}
 	case "finalized_checkpoint":
 		e.Data = &FinalizedCheckpointEvent{}
 	case "head":

--- a/api/v1/fastconfirmationevent.go
+++ b/api/v1/fastconfirmationevent.go
@@ -1,0 +1,91 @@
+// Copyright © 2026 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/ethpandaops/go-eth2-client/spec/phase0"
+	"github.com/pkg/errors"
+)
+
+// FastConfirmationEvent is the data for the fast confirmation event.
+type FastConfirmationEvent struct {
+	Slot  phase0.Slot
+	Block phase0.Root
+}
+
+// fastConfirmationEventJSON is the spec representation of the struct.
+type fastConfirmationEventJSON struct {
+	Slot  string `json:"slot"`
+	Block string `json:"block"`
+}
+
+// MarshalJSON implements json.Marshaler.
+func (e *FastConfirmationEvent) MarshalJSON() ([]byte, error) {
+	return json.Marshal(&fastConfirmationEventJSON{
+		Slot:  fmt.Sprintf("%d", e.Slot),
+		Block: fmt.Sprintf("%#x", e.Block),
+	})
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (e *FastConfirmationEvent) UnmarshalJSON(input []byte) error {
+	var data fastConfirmationEventJSON
+	if err := json.Unmarshal(input, &data); err != nil {
+		return errors.Wrap(err, "invalid JSON")
+	}
+
+	if data.Slot == "" {
+		return errors.New("slot missing")
+	}
+
+	slot, err := strconv.ParseUint(data.Slot, 10, 64)
+	if err != nil {
+		return errors.Wrap(err, "invalid value for slot")
+	}
+
+	e.Slot = phase0.Slot(slot)
+
+	if data.Block == "" {
+		return errors.New("block missing")
+	}
+
+	block, err := hex.DecodeString(strings.TrimPrefix(data.Block, "0x"))
+	if err != nil {
+		return errors.Wrap(err, "invalid value for block")
+	}
+
+	if len(block) != rootLength {
+		return fmt.Errorf("incorrect length %d for block", len(block))
+	}
+
+	copy(e.Block[:], block)
+
+	return nil
+}
+
+// String returns a string version of the structure.
+func (e *FastConfirmationEvent) String() string {
+	data, err := json.Marshal(e)
+	if err != nil {
+		return fmt.Sprintf("ERR: %v", err)
+	}
+
+	return string(data)
+}

--- a/http/events.go
+++ b/http/events.go
@@ -154,6 +154,8 @@ func (*Service) checkEventSpecificHandler(opts *api.EventsOpts, topic string) er
 		hasHandler = opts.ExecutionPayloadBidHandler != nil
 	case "execution_payload_gossip":
 		hasHandler = opts.ExecutionPayloadGossipHandler != nil
+	case "fast_confirmation":
+		hasHandler = opts.FastConfirmationHandler != nil
 	case "finalized_checkpoint":
 		hasHandler = opts.FinalizedCheckpointHandler != nil
 	case "head":
@@ -221,6 +223,8 @@ func (s *Service) handleEvent(ctx context.Context,
 		s.handleExecutionPayloadBidEvent(ctx, msg, opts)
 	case "execution_payload_gossip":
 		s.handleExecutionPayloadGossipEvent(ctx, msg, opts)
+	case "fast_confirmation":
+		s.handleFastConfirmationEvent(ctx, msg, opts)
 	case "finalized_checkpoint":
 		s.handleFinalizedCheckpointEvent(ctx, msg, opts)
 	case "head":
@@ -369,6 +373,33 @@ func (*Service) handleBlockGossipEvent(ctx context.Context,
 	switch {
 	case opts.BlockGossipHandler != nil:
 		opts.BlockGossipHandler(ctx, data)
+	case opts.Handler != nil:
+		opts.Handler(&apiv1.Event{
+			Topic: string(msg.Event),
+			Data:  data,
+		})
+	default:
+		log.Debug().Msg("No specific or generic handler supplied; ignoring")
+	}
+}
+
+func (*Service) handleFastConfirmationEvent(ctx context.Context,
+	msg *sse.Event,
+	opts *api.EventsOpts,
+) {
+	log := zerolog.Ctx(ctx)
+	data := &apiv1.FastConfirmationEvent{}
+
+	err := json.Unmarshal(msg.Data, data)
+	if err != nil {
+		log.Error().Err(err).RawJSON("data", msg.Data).Msg("Failed to parse fast confirmation event")
+
+		return
+	}
+
+	switch {
+	case opts.FastConfirmationHandler != nil:
+		opts.FastConfirmationHandler(ctx, data)
 	case opts.Handler != nil:
 		opts.Handler(&apiv1.Event{
 			Topic: string(msg.Event),


### PR DESCRIPTION
Adds support for the new `fast_confirmation` SSE event introduced in [ethereum/beacon-APIs#598](https://github.com/ethereum/beacon-APIs/pull/598). The event carries a beacon block root and slot, emitted once per slot after execution of the Fast confirmation rule.

Mirrors the existing `block_gossip` pattern: `FastConfirmationEvent` struct, generic + topic-specific handler wiring, and topic registration in `SupportedEventTopics`.