### PR TITLE
fix: pluralize execution_payload_envelopes endpoint path

### DIFF
--- a/http/signedexecutionpayloadenvelope.go
+++ b/http/signedexecutionpayloadenvelope.go
@@ -131,7 +131,7 @@ func (s *Service) fetchSignedExecutionPayloadEnvelope(ctx context.Context,
 		return nil, errors.Join(errors.New("no block specified"), client.ErrInvalidOptions)
 	}
 
-	endpoint := fmt.Sprintf("/eth/v1/beacon/execution_payload_envelope/%s", opts.Block)
+	endpoint := fmt.Sprintf("/eth/v1/beacon/execution_payload_envelopes/%s", opts.Block)
 
 	httpResponse, err := s.get(ctx, endpoint, "", &opts.Common, true)
 	if err != nil {


### PR DESCRIPTION
## Summary
- Align the `GET execution_payload_envelope/{block_id}` route with [beacon-APIs PR #613](https://github.com/ethereum/beacon-APIs/pull/613), which pluralizes the gloas execution payload routes so they match the REST naming convention used elsewhere in the spec (`blocks`, `states`, etc.).
- This is a breaking change on the beacon-APIs side, but [dora](https://github.com/ethpandaops/dora) is the only known consumer of these envelope endpoints.

## Test plan
- [ ] CI passes
- [ ] Manual verification against a CL client that ships the renamed route