### PR TITLE
fix(http): unwrap JSON data envelope for execution payload envelopes

### DIFF
--- a/http/events.go
+++ b/http/events.go
@@ -771,7 +771,7 @@ func (*Service) handleExecutionPayloadBidEvent(ctx context.Context,
 	log := zerolog.Ctx(ctx)
 	data := &gloas.SignedExecutionPayloadBid{}
 
-	err := json.Unmarshal(msg.Data, data)
+	err := unmarshalVersionedEventData(msg.Data, data)
 	if err != nil {
 		log.Error().Err(err).RawJSON("data", msg.Data).Msg("Failed to parse execution payload bid event")
 
@@ -818,6 +818,23 @@ func (*Service) handleExecutionPayloadGossipEvent(ctx context.Context,
 	}
 }
 
+
+// unmarshalVersionedEventData decodes an SSE event payload that the beacon-API
+// spec wraps as {"version": "...", "data": {...}}. Some clients (Prysm) still
+// send the bare unwrapped object, so that shape is accepted as a fallback.
+func unmarshalVersionedEventData(raw []byte, v any) error {
+	var wrapper struct {
+		Version string          `json:"version"`
+		Data    json.RawMessage `json:"data"`
+	}
+
+	if err := json.Unmarshal(raw, &wrapper); err == nil && len(wrapper.Data) > 0 && wrapper.Version != "" {
+		return json.Unmarshal(wrapper.Data, v)
+	}
+
+	return json.Unmarshal(raw, v)
+}
+
 func (*Service) handlePayloadAttestationMessageEvent(ctx context.Context,
 	msg *sse.Event,
 	opts *api.EventsOpts,
@@ -825,7 +842,7 @@ func (*Service) handlePayloadAttestationMessageEvent(ctx context.Context,
 	log := zerolog.Ctx(ctx)
 	data := &gloas.PayloadAttestationMessage{}
 
-	err := json.Unmarshal(msg.Data, data)
+	err := unmarshalVersionedEventData(msg.Data, data)
 	if err != nil {
 		log.Error().Err(err).RawJSON("data", msg.Data).Msg("Failed to parse payload attestation message event")
 
@@ -852,7 +869,7 @@ func (*Service) handleProposerPreferencesEvent(ctx context.Context,
 	log := zerolog.Ctx(ctx)
 	data := &gloas.SignedProposerPreferences{}
 
-	err := json.Unmarshal(msg.Data, data)
+	err := unmarshalVersionedEventData(msg.Data, data)
 	if err != nil {
 		log.Error().Err(err).RawJSON("data", msg.Data).Msg("Failed to parse proposer preferences event")
 

--- a/http/events_versioned_test.go
+++ b/http/events_versioned_test.go
@@ -1,0 +1,26 @@
+package http
+
+import (
+	"testing"
+
+	"github.com/ethpandaops/go-eth2-client/spec/gloas"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Lighthouse (spec-compliant) wraps gloas SSE payloads in a versioned
+// envelope; Prysm sends the bare object. Both must decode.
+func TestUnmarshalVersionedEventData(t *testing.T) {
+	bare := `{"validator_index":"325","data":{"beacon_block_root":"0x5793a892cd76b015aaaaaf8251a3061bbdb79cb7547fd926208e9beffec67e96","slot":"54715","payload_present":true,"blob_data_available":true},"signature":"0x946643c1b1d601a969fa99680e7d27701ad7c98ab4569caa6d76ed523cc74c1aa81361737ca37e42a21ae659d390bf580166086ccb6b412ad9463eceb31a1a54ac2c9b1c5238181f2ea7cb85750d332763908746f6035bfad655228a4ce45440"}`
+	wrapped := `{"version":"gloas","data":` + bare + `}`
+
+	for name, payload := range map[string]string{"bare": bare, "wrapped": wrapped} {
+		t.Run(name, func(t *testing.T) {
+			msg := &gloas.PayloadAttestationMessage{}
+			require.NoError(t, unmarshalVersionedEventData([]byte(payload), msg))
+			assert.Equal(t, uint64(325), uint64(msg.ValidatorIndex))
+			assert.Equal(t, uint64(54715), uint64(msg.Data.Slot))
+			assert.True(t, msg.Data.PayloadPresent)
+		})
+	}
+}

--- a/http/signedexecutionpayloadenvelope.go
+++ b/http/signedexecutionpayloadenvelope.go
@@ -14,9 +14,11 @@
 package http
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 
 	client "github.com/ethpandaops/go-eth2-client"
 	"github.com/ethpandaops/go-eth2-client/api"
@@ -42,6 +44,7 @@ func (s *Service) SignedExecutionPayloadEnvelope(ctx context.Context,
 	// All current envelope-bearing forks (Gloas, Heze) reuse the gloas
 	// schema, so the wire bytes always parse into *gloas.SignedExecutionPayloadEnvelope.
 	envelope := &gloas.SignedExecutionPayloadEnvelope{}
+	metadata := metadataFromHeaders(httpResponse.headers)
 
 	switch httpResponse.contentType {
 	case ContentTypeSSZ:
@@ -54,9 +57,14 @@ func (s *Service) SignedExecutionPayloadEnvelope(ctx context.Context,
 			return nil, errors.Join(fmt.Errorf("failed to decode %s signed execution payload envelope", httpResponse.consensusVersion), err)
 		}
 	case ContentTypeJSON:
-		if err := envelope.UnmarshalJSON(httpResponse.body); err != nil {
+		decoded, jsonMetadata, err := decodeJSONResponse(bytes.NewReader(httpResponse.body), envelope)
+		if err != nil {
 			return nil, errors.Join(fmt.Errorf("failed to decode %s signed execution payload envelope", httpResponse.consensusVersion), err)
 		}
+
+		envelope = decoded
+
+		maps.Copy(metadata, jsonMetadata)
 	default:
 		return nil, fmt.Errorf("unhandled content type %v", httpResponse.contentType)
 	}
@@ -66,7 +74,7 @@ func (s *Service) SignedExecutionPayloadEnvelope(ctx context.Context,
 			Version: httpResponse.consensusVersion,
 			Gloas:   envelope,
 		},
-		Metadata: metadataFromHeaders(httpResponse.headers),
+		Metadata: metadata,
 	}, nil
 }
 
@@ -87,6 +95,7 @@ func (s *Service) AgnosticSignedExecutionPayloadEnvelope(ctx context.Context,
 	}
 
 	envelope := &all.SignedExecutionPayloadEnvelope{Version: httpResponse.consensusVersion}
+	metadata := metadataFromHeaders(httpResponse.headers)
 
 	switch httpResponse.contentType {
 	case ContentTypeSSZ:
@@ -99,16 +108,21 @@ func (s *Service) AgnosticSignedExecutionPayloadEnvelope(ctx context.Context,
 			return nil, errors.Join(fmt.Errorf("failed to decode %s signed execution payload envelope", httpResponse.consensusVersion), err)
 		}
 	case ContentTypeJSON:
-		if err := envelope.UnmarshalJSON(httpResponse.body); err != nil {
+		decoded, jsonMetadata, err := decodeJSONResponse(bytes.NewReader(httpResponse.body), envelope)
+		if err != nil {
 			return nil, errors.Join(fmt.Errorf("failed to decode %s signed execution payload envelope", httpResponse.consensusVersion), err)
 		}
+
+		envelope = decoded
+
+		maps.Copy(metadata, jsonMetadata)
 	default:
 		return nil, fmt.Errorf("unhandled content type %v", httpResponse.contentType)
 	}
 
 	return &api.Response[*all.SignedExecutionPayloadEnvelope]{
 		Data:     envelope,
-		Metadata: metadataFromHeaders(httpResponse.headers),
+		Metadata: metadata,
 	}, nil
 }
 


### PR DESCRIPTION
The JSON path of `SignedExecutionPayloadEnvelope` and `AgnosticSignedExecutionPayloadEnvelope` passed the raw response body to `UnmarshalJSON`, which fails with `message missing` because beacon nodes wrap the payload as `{"version":...,"data":{...}}`. SSZ responses were unaffected, which hid the bug from SSZ-preferring clients — xatu cannon negotiates JSON and could not fetch any envelope from glamsterdam-devnet-6 (every envelope-sourced deriver failed).

Fix: use `decodeJSONResponse` like the other endpoints so the `data` field is extracted and response metadata is preserved.

Verification:
- The [beacon-APIs spec for the endpoint](https://github.com/ethereum/beacon-APIs/blob/master/apis/beacon/execution_payload/envelope_get.yaml) requires the JSON response shape `{version, execution_optimistic, finalized, data}` — unwrapping `data` is the spec-mandated behavior, not a client quirk.
- Confirmed live against glamsterdam-devnet-6 on two client implementations: Nimbus and Prysm both return the spec wrapper and decode correctly with this fix (verified via connection-pinned `/eth/v1/node/version` + envelope requests through the network's load-balanced endpoint).
- xatu cannon's envelope-sourced derivers proceed with this fix applied.

Side observation from testing (not addressed here): envelope *retention* varies by client — Nimbus serves historical envelopes, Prysm only a narrow near-head window (404 `execution payload envelope not found` otherwise).